### PR TITLE
feature/empty_corner_tables

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,6 +30,13 @@ def test_df_find_tables_loose(xlsx):
     assert (102, 2, 'C103', 'Schedule of Principal Repayments:') in t
 
 
+def test_df_find_tables_na_depth(xlsx):
+    t = df_find_tables(xlsx, na_depth=2)
+    assert len(t) == 17
+    assert (1, 2, 'C2', 'nan') in t
+    assert (25, 2, 'C26', 'nan') in t
+
+
 def test_df_parse_table(xlsx):
     t = df_parse_table(xlsx, 102, 2)
     assert t.shape == (11, 8)


### PR DESCRIPTION
core: 

- Added proposed na_depth to df_find_tables.
- Changed isna_above logic to be true if cells [ c to c + na_depth ] at r-1 are all empty.
- Changed isna_right logic to be true if cells [ c to c + na_depth ] at r are all empty.
- Changed isna_down logic to be true if cells [ r+1 to r + na_depth ] are all empty.
- Changed isna_corner logic tobe true if cells ([ c to c + na_depth ], [ r to r + na_depth]) are all empty.
- all these variables behaviour is the same as before for na_depth = 1
- Added a isghost_corner variable that checks if there is data on the same row but up to na_depth cells to the right
-Updated result.append to include a cell when is considered a ghost cell even if empty.


test_core: Added unit test for feature